### PR TITLE
Enable proc_macro support on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ script:
   - cargo build
   - cargo build --no-default-features --features 'dummy'
   - cargo test --no-default-features --features 'dummy'
-  # Not implemented yet
-  # - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo build --no-default-features --features 'proc-macro')
+  - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo build --no-default-features --features 'proc-macro')
   - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo build --features 'i128')
 
 notifications:


### PR DESCRIPTION
rust-lang/rust#40939 has been in the last few nightlies now, so I think we're ready to start testing it.