### PR TITLE
Fix support for unicode escape codes.

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -151,7 +151,7 @@ pub(crate) fn str_lit(mut s: &str) -> Option<String> {
                         char::from_u32(byte as u32).unwrap()
                     }
                     b'u' => {
-                        let (rest, chr) = backslash_u(&s[2..]);
+                        let (rest, chr) = backslash_u(&s);
                         s = rest;
                         chr
                     }
@@ -163,7 +163,6 @@ pub(crate) fn str_lit(mut s: &str) -> Option<String> {
                     b'\'' => '\'',
                     b'"' => '"',
                     b'\r' | b'\n' => {
-                        s = &s[2..];
                         loop {
                             let ch = next_chr(s);
                             if ch.is_whitespace() {
@@ -280,7 +279,7 @@ pub(crate) fn char_lit(mut s: &str) -> Option<char> {
                     char::from_u32(byte as u32).unwrap()
                 }
                 b'u' => {
-                    let (rest, chr) = backslash_u(&s[2..]);
+                    let (rest, chr) = backslash_u(s);
                     s = rest;
                     chr
                 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -109,6 +109,7 @@ fn chars() {
     test_char!('🐕'); // NOTE: This is an emoji
     test_char!('\'');
     test_char!('"');
+    test_char!('\u{1F415}');
 }
 
 #[test]
@@ -159,6 +160,7 @@ fn string() {
     test_string!("\"");
     test_string!("'");
     test_string!("");
+    test_string!("\u{1F415}");
     test_string!("This
            String contains\
            newlines and other such


### PR DESCRIPTION
The `\u` sequence was previously skipped twice, which made parsing unicode escape codes fail.